### PR TITLE
Fix changes to existing groups not being persisted

### DIFF
--- a/src/SaveAllTheTabs/DocumentManager.cs
+++ b/src/SaveAllTheTabs/DocumentManager.cs
@@ -184,6 +184,7 @@ namespace SaveAllTheTabs
                     group.Description = documents;
                     group.Files = files;
                     group.Positions = stream.ToArray();
+                    Groups[Groups.IndexOf(group)] = group;
 
                     TrySetSlot(group, slot);
                 }


### PR DESCRIPTION
When making changes to existing tab groups and then exiting Visual Studio, those changes do not persist and are lost. The issue is that replacing data within the collection does not trigger collection change events. This change forces that notification to occur so that the changes are saved.